### PR TITLE
Bump bs-platform dep to v7.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.1.1
+Bump `bs-platform` dependency to v7.0.0.
+
 ## 0.1.0
 Update `align-*` & `justify-*` types.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 0.1.1
+## 1.0.0
 Bump `bs-platform` dependency to v7.0.0.
 
 ## 0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minima.app/re-css",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ReasonML bindings to CSS",
   "author": "Alex Fedoseev <alex.fedoseev@gmail.com>",
   "license": "MIT",
@@ -26,9 +26,9 @@
     "url": "https://github.com/minima-app/re-css.git"
   },
   "peerDependencies": {
-    "bs-platform": "^4.0.5"
+    "bs-platform": "^7.0.0"
   },
   "devDependencies": {
-    "bs-platform": "4.0.7"
+    "bs-platform": "7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minima.app/re-css",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "ReasonML bindings to CSS",
   "author": "Alex Fedoseev <alex.fedoseev@gmail.com>",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-bs-platform@4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.7.tgz#1a0bbf0fef439fef5f1a88ba60d5ac8a6d73570c"
-  integrity sha512-39ZXSugB03PznE7eSVwxq5z4S8Cn44r22T2eFd7rgFQ94HaB/mCNHXG0epF3mJLYhhhyPT9w3e/t+FAIjSdAkg==
+bs-platform@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.0.0.tgz#6d1b0dd0d53f16f5b7fb2656ccae58c71ec988dc"
+  integrity sha512-3cPwrt/1hGjXuGS2HfVyd6oc6p/YpDOQIoLiFLRgrrB7/bnDNvbJn4XhO1PUyuRL4e7fc24R3xvA08BFDHZ6Gw==


### PR DESCRIPTION
What the title says :)

Without this update, there are warnings as downstream dependents like `bs-emotion` have already bumped their dependency.

I tried to make the PR "publish-ready", but the only question is if version change should be patch (like now), minor or major. I'm not sure what happens in these cases.

Tested by compiling `bs-emotion` lib with this PR linked locally.